### PR TITLE
Fetch only the first page of the friends/planet stream

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -53,7 +53,7 @@ if not WGET_AT:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20200721.02'
+VERSION = '20200721.03'
 USER_AGENT = 'Googlebot'
 TRACKER_ID = 'soup-io'
 TRACKER_HOST = 'trackerproxy.meo.ws'

--- a/soup-io.lua
+++ b/soup-io.lua
@@ -46,6 +46,7 @@ allowed = function(url, parenturl)
     or string.match(url, "^https?://[^/]+/rss$")
     or string.match(url, "^https?://[^/]+/none$")
     or string.match(url, "^https?://[^/]+/rss/original$")
+    or string.match(url, "^https?://[^/]+/planet%?.+")
     or string.match(url, "^https?://[^/]+/friends%?.+") then
     return false
   end

--- a/soup-io.lua
+++ b/soup-io.lua
@@ -46,7 +46,7 @@ allowed = function(url, parenturl)
     or string.match(url, "^https?://[^/]+/rss$")
     or string.match(url, "^https?://[^/]+/none$")
     or string.match(url, "^https?://[^/]+/rss/original$")
-    or string.match(url, "^https?://[^/]+/friends%?.*since=0") then
+    or string.match(url, "^https?://[^/]+/friends%?.+") then
     return false
   end
 


### PR DESCRIPTION
The idea is to only fetch the first page of the friends stream (`/friends`) so we still get the followers list, but not fetch all other pages from there. As the friends stream is the aggregate of all the content from users that soup follows it would be exponentially larger. With the very limited time we have left my idea is to focus the resources on the soups main content.

Update: `/planet` is similar to `/friends` but for "group soups". So a stream of all group members. I've added a line to treat it the same.
