### PR TITLE
Fake DNS responses for certain domains

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -53,7 +53,7 @@ if not WGET_AT:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20200717.03'
+VERSION = '20200721.01'
 USER_AGENT = 'Googlebot'
 TRACKER_ID = 'soup-io'
 TRACKER_HOST = 'trackerproxy.meo.ws'

--- a/pipeline.py
+++ b/pipeline.py
@@ -53,7 +53,7 @@ if not WGET_AT:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20200721.01'
+VERSION = '20200721.02'
 USER_AGENT = 'Googlebot'
 TRACKER_ID = 'soup-io'
 TRACKER_HOST = 'trackerproxy.meo.ws'

--- a/soup-io.lua
+++ b/soup-io.lua
@@ -96,8 +96,13 @@ wget.callbacks.lookup_host = function(host)
       return "45.153.143.249"
     end
   end
+  
+  if string.match(host, "^static%.soup%.io$") ~= nil then
+    return "45.153.143.247"
+  end
+  
   if host:lower() == item_value:lower() then
-     return "45.153.143.247"
+    return "45.153.143.247"
   end
 
   -- Else, use the real address

--- a/soup-io.lua
+++ b/soup-io.lua
@@ -91,10 +91,8 @@ end
 wget.callbacks.lookup_host = function(host)
   if string.match(host, "^asset%.soup%.io$") ~= nil then
     if string.len(item_value) % 2 == 0 then
-      print("Using 248")
       return "45.153.143.248"
     else
-      print("Using 249")
       return "45.153.143.249"
     end
   end

--- a/soup-io.lua
+++ b/soup-io.lua
@@ -88,6 +88,24 @@ allowed = function(url, parenturl)
   return false
 end
 
+wget.callbacks.lookup_host = function(host)
+  if string.match(host, "^asset%.soup%.io$") ~= nil then
+    if string.len(item_value) % 2 == 0 then
+      print("Using 248")
+      return "45.153.143.248"
+    else
+      print("Using 249")
+      return "45.153.143.249"
+    end
+  end
+  if host:lower() == item_value:lower() then
+     return "45.153.143.247"
+  end
+
+  -- Else, use the real address
+  return nil
+end
+
 wget.callbacks.download_child_p = function(urlpos, parent, depth, start_url_parsed, iri, verdict, reason)
   local url = urlpos["url"]["url"]
   local html = urlpos["link_expect_html"]


### PR DESCRIPTION
About half a day ago, soup.io began resolving to some spam site. But, it was discovered that the original server is still up. This commit has wget-lua fake a DNS reponse for the domain covered by the current item, and for asset.soup.io, in order to get those, and let this project continue.

This tries to be very conservative. The only "interesting" element of this is that it changes which of the two assets. servers it uses depending on the parity of the item name (to try to even out the load).